### PR TITLE
Fix parser path in parser-test

### DIFF
--- a/parser-test.org
+++ b/parser-test.org
@@ -224,7 +224,7 @@ for wasm_file in "$WASM_DIR"/*.wasm; do
   echo -n "Testing $base_name: "
   log_file="$TEST_LOGS/${base_name%.wasm}.log"
 
-  if ./parser "$wasm_file" > "$log_file" 2>&1; then
+  if ../parser "$wasm_file" > "$log_file" 2>&1; then
     echo -e "${GREEN}PASS${NC}"
   else
     echo -e "${RED}FAIL${NC} (return code: $?)"


### PR DESCRIPTION
## Summary
- update parser path in parser-test.org to reference the parent directory
- regenerate `tests/run_tests.sh`

## Testing
- `./tests/run_tests.sh` *(fails: wat2wasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9d99fa08331b8555dc5310588b5