### PR TITLE
Implement minimal WebAssembly parser stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 ./tests/*.wat
 ./tests/Makefile
 ./tests/run_tests.sh
+
+# Ignore build artifacts
+src/parser
+src/*.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,16 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -std=c11
+
+all: parser
+
+parser: main.o parse_module.o
+	$(CC) $(CFLAGS) -o $@ $^
+
+main.o: main.c parse_module.h
+	$(CC) $(CFLAGS) -c -o $@ main.c
+
+parse_module.o: parse_module.c parse_module.h
+	$(CC) $(CFLAGS) -c -o $@ parse_module.c
+
+clean:
+	rm -f parser main.o parse_module.o

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "parse_module.h"
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <wasm-file>\n", argv[0]);
+        return 1;
+    }
+    FILE *f = fopen(argv[1], "rb");
+    if (!f) {
+        perror("open");
+        return 1;
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    unsigned char *buf = malloc(size);
+    if (!buf) {
+        fprintf(stderr, "malloc failed\n");
+        fclose(f);
+        return 1;
+    }
+    if (fread(buf, 1, size, f) != (size_t)size) {
+        perror("fread");
+        free(buf);
+        fclose(f);
+        return 1;
+    }
+    fclose(f);
+    struct Module *module = NULL;
+    Result r = parse_module(NULL, &module, buf, size);
+    if (r) {
+        fprintf(stderr, "parse error: %s\n", r);
+        free(buf);
+        return 1;
+    }
+    printf("parsed successfully\n");
+    free(module);
+    free(buf);
+    return 0;
+}

--- a/src/parse_module.c
+++ b/src/parse_module.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef const char * Result;
+
+struct Environment;
+typedef struct Environment * IEnvironment;
+
+struct Module {
+    /* placeholder for future members */
+};
+typedef struct Module * IModule;
+
+static const uint8_t WASM_MAGIC[] = {0x00, 0x61, 0x73, 0x6d};
+static const uint8_t WASM_VERSION[] = {0x01, 0x00, 0x00, 0x00};
+
+Result parse_module(IEnvironment env, IModule *out, const uint8_t *wasm, uint32_t size)
+{
+    if (!wasm || size < 8)
+        return "file_too_small";
+
+    if (memcmp(wasm, WASM_MAGIC, 4) != 0)
+        return "bad_magic";
+
+    if (memcmp(wasm + 4, WASM_VERSION, 4) != 0)
+        return "bad_version";
+
+    *out = malloc(sizeof(**out));
+    if (!*out)
+        return "malloc_failed";
+
+    /* real parsing is TODO */
+    return NULL; /* Err_none */
+}

--- a/src/parse_module.h
+++ b/src/parse_module.h
@@ -1,0 +1,13 @@
+#ifndef PARSE_MODULE_H
+#define PARSE_MODULE_H
+#include <stdint.h>
+
+typedef const char * Result;
+struct Environment;
+typedef struct Environment * IEnvironment;
+struct Module;
+typedef struct Module * IModule;
+
+Result parse_module(IEnvironment env, IModule *out, const uint8_t *wasm, uint32_t size);
+
+#endif


### PR DESCRIPTION
## Summary
- implement a basic `parse_module` function
- add a small CLI example and Makefile
- ignore built binaries

## Testing
- `cd src && make clean && make`
- `./parser /bin/ls`

------
https://chatgpt.com/codex/tasks/task_e_6853b7fba2008331b492f4cad0fa2e3f